### PR TITLE
Error on unrecognised output format (JS)

### DIFF
--- a/crates/proc/src/disamb/test.rs
+++ b/crates/proc/src/disamb/test.rs
@@ -119,8 +119,7 @@ fn test() {
     db.insert_references(vec![refr, refr2]);
     let mut interner = string_interner::StringInterner::default();
     let id = interner.get_or_intern("1");
-    db.init_clusters(vec![(id, vec![Cite::basic("ref_id")])]);
-    db.set_cluster_note_number(id, Some(ClusterNumber::Note(IntraNote::Single(1))));
+    db.init_clusters(vec![(id, ClusterNumber::Note(IntraNote::Single(1)), vec![Cite::basic("ref_id")])]);
     let cite_ids = db.cluster_cites(id);
 
     let get_stream = |ind: usize| {

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -473,6 +473,10 @@ let positions = [ ... before, { note: 34 }, ... after ];
 let preview = driver.previewCitationCluster(cites, positions, "html").unwrap();
 ```
 
+The format argument is like the format passed to `Driver.new`: one of `"html"`,
+`"rtf"` or `"plain"`. The driver will use that instead of its normal output
+format.
+
 The positions array is exactly like a call to `setClusterOrder`, except exactly 
 one of the positions omits the id field. This could either:
 

--- a/crates/wasm/js-tests/index.test.ts
+++ b/crates/wasm/js-tests/index.test.ts
@@ -1,143 +1,171 @@
 import { withDriver, oneOneOne, mkStyle, checkUpdatesLen } from './utils';
 import {UpdateSummary} from '@citeproc-rs/wasm';
 
-test('boots', () => {
-    withDriver({}, driver => {
-        expect(driver).not.toBeNull();
+describe("Driver", () => {
+
+    test('boots', () => {
+        withDriver({}, driver => {
+            expect(driver).not.toBeNull();
+        });
+    });
+
+    test('returns a single cluster, single cite, single ref', () => {
+        withDriver({}, driver => {
+            expect(driver).not.toBeNull();
+            oneOneOne(driver);
+            driver.insertReference({ id: "citekey", type: "book", title: "TEST_TITLE" });
+            driver.initClusters([{id: "one", cites: [{id: "citekey"}]}]);
+            driver.setClusterOrder([{ id: "one" }]);
+            let res = driver.builtCluster("one").unwrap();
+            expect(res).toBe("TEST_TITLE");
+        });
     });
 });
 
-test('returns a single cluster, single cite, single ref', () => {
-    withDriver({}, driver => {
-        expect(driver).not.toBeNull();
-        oneOneOne(driver);
-        driver.insertReference({ id: "citekey", type: "book", title: "TEST_TITLE" });
-        driver.initClusters([{id: "one", cites: [{id: "citekey"}]}]);
-        driver.setClusterOrder([{ id: "one" }]);
-        let res = driver.builtCluster("one").unwrap();
-        expect(res).toBe("TEST_TITLE");
+describe("batchedUpdates", () => {
+    test('gets an update when ref changes', () => {
+        withDriver({}, driver => {
+            oneOneOne(driver);
+            let updates = driver.batchedUpdates().unwrap();
+            expect(updates.clusters).toContainEqual(["one", "TEST_TITLE"]);
+            driver.insertReference({ id: "citekey", type: "book", title: "TEST_TITLE_2" });
+            updates = driver.batchedUpdates().unwrap();
+            expect(updates.clusters).toContainEqual(["one", "TEST_TITLE_2"]);
+        });
     });
-});
 
-test('gets an update when ref changes', () => {
-    withDriver({}, driver => {
-        oneOneOne(driver);
-        let updates = driver.batchedUpdates().unwrap();
-        expect(updates.clusters).toContainEqual(["one", "TEST_TITLE"]);
-        driver.insertReference({ id: "citekey", type: "book", title: "TEST_TITLE_2" });
-        updates = driver.batchedUpdates().unwrap();
-        expect(updates.clusters).toContainEqual(["one", "TEST_TITLE_2"]);
+    let bibStyle = mkStyle(
+        '<text variable="title" />',
+        `<bibliography>
+            <layout>
+                <text variable = "title" />
+            </layout>
+        </bibliography>`
+    );
+
+    test('fullRender works', () => {
+        withDriver({style: bibStyle}, driver => {
+            oneOneOne(driver);
+            let full = driver.fullRender().unwrap();
+            expect(full.allClusters).toHaveProperty("one", "TEST_TITLE");
+            expect(full.bibEntries).toContainEqual({ id: "citekey", value: "TEST_TITLE" });
+        })
     });
+
+    test('update queue generally', () => {
+        withDriver({style: bibStyle}, driver => {
+            let once: UpdateSummary, twice: UpdateSummary;
+
+            // Initially empty
+            checkUpdatesLen(driver.batchedUpdates().unwrap(), 0, 0);
+
+            // Add stuff, check it creates
+            oneOneOne(driver);
+            checkUpdatesLen(driver.batchedUpdates().unwrap(), 1, 1);
+
+            // Now fullRender one should drain the queue.
+            driver.fullRender();
+            checkUpdatesLen(driver.batchedUpdates().unwrap(), 0, 0);
+
+            // Edit a reference
+            oneOneOne(driver, { title: "ALTERED" });
+            let up = driver.batchedUpdates().unwrap();
+            checkUpdatesLen(up, 1, 1);
+            expect(up.bibliography?.entryIds).toEqual(null);
+            expect(driver.builtCluster("one").unwrap()).toBe("ALTERED");
+
+            // Should have no updates, as we just called batchedUpdates.
+            once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
+            expect(once).toEqual(twice);
+            expect(once.bibliography).toBeFalsy();
+            checkUpdatesLen(once, 0, 0);
+
+            // Only inserting a reference does nothing
+            driver.insertReference({ id: "added", type: "book", title: "ADDED" });
+            once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
+            expect(once).toEqual(twice);
+
+            // Only inserting a cluster not in the document does nothing
+            driver.insertCluster({ id: "123", cites: [{ id: "added" }] }).unwrap();
+            once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
+            expect(once).toEqual(twice); checkUpdatesLen(once, 0, 0);
+
+            // Add it to the document, and it's a different story
+            driver.setClusterOrder([ {id:"one"},{id:"123"} ]).unwrap();
+            once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
+            expect(once).not.toEqual(twice); checkUpdatesLen(twice, 0, 0);
+            expect(once.clusters).toContainEqual(["123", "ADDED"]);
+            expect(once.bibliography?.entryIds).toEqual(["citekey", "added"]);
+            expect(once.bibliography?.updatedEntries).toHaveProperty("added", "ADDED");
+        })
+    });
+
 });
 
-let bibStyle = mkStyle(
-    '<text variable="title" />',
-    `<bibliography>
-        <layout>
-            <text variable = "title" />
-        </layout>
-    </bibliography>`
-);
+describe("previewCitationCluster", () => {
 
-test('fullRender works', () => {
-    withDriver({style: bibStyle}, driver => {
-        oneOneOne(driver);
-        let full = driver.fullRender().unwrap();
-        expect(full.allClusters).toHaveProperty("one", "TEST_TITLE");
-        expect(full.bibEntries).toContainEqual({ id: "citekey", value: "TEST_TITLE" });
+    let ibidStyle = mkStyle(
+        `
+        <choose>
+            <if position="ibid">
+                <text value="ibid" />
+            </if>
+            <else>
+                <text variable="title" />
+            </else>
+        </choose>
+        `,
+        ``,
+    );
+
+    function pccSetup(callback) {
+        withDriver({ style: ibidStyle }, driver => {
+            let one = "cluster-one";
+            let two = "cluster-two";
+            oneOneOne(driver, { title: "ONE", id: "r1" }, "cluster-one");
+            oneOneOne(driver, { title: "TWO", id: "r2" }, "cluster-two");
+            driver.setClusterOrder([{ id: one }, { id: two }]).unwrap();
+            callback(driver, [one, two]);
+        })
+    }
+
+    // There are more extensive tests already in rust, so this is more of a smoke test.
+    test("between two other clusters", () => {
+        pccSetup((driver, [one, two]) => {
+            // between the other two
+            let pcc = driver.previewCitationCluster(
+                [ { id: "r1" } ],
+                [{ id: one }, { }, { id: two }],
+                "plain"
+            ).unwrap();
+            expect(pcc).toEqual("ibid");
+        })
     })
-});
 
-test('update queue generally', () => {
-    withDriver({style: bibStyle}, driver => {
-        let once: UpdateSummary, twice: UpdateSummary;
-
-        // Initially empty
-        checkUpdatesLen(driver.batchedUpdates().unwrap(), 0, 0);
-
-        // Add stuff, check it creates
-        oneOneOne(driver);
-        checkUpdatesLen(driver.batchedUpdates().unwrap(), 1, 1);
-
-        // Now fullRender one should drain the queue.
-        driver.fullRender();
-        checkUpdatesLen(driver.batchedUpdates().unwrap(), 0, 0);
-
-        // Edit a reference
-        oneOneOne(driver, { title: "ALTERED" });
-        let up = driver.batchedUpdates().unwrap();
-        checkUpdatesLen(up, 1, 1);
-        expect(up.bibliography?.entryIds).toEqual(null);
-        expect(driver.builtCluster("one").unwrap()).toBe("ALTERED");
-
-        // Should have no updates, as we just called batchedUpdates.
-        once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
-        expect(once).toEqual(twice);
-        expect(once.bibliography).toBeFalsy();
-        checkUpdatesLen(once, 0, 0);
-
-        // Only inserting a reference does nothing
-        driver.insertReference({ id: "added", type: "book", title: "ADDED" });
-        once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
-        expect(once).toEqual(twice);
-
-        // Only inserting a cluster not in the document does nothing
-        driver.insertCluster({ id: "123", cites: [{ id: "added" }] }).unwrap();
-        once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
-        expect(once).toEqual(twice); checkUpdatesLen(once, 0, 0);
-
-        // Add it to the document, and it's a different story
-        driver.setClusterOrder([ {id:"one"},{id:"123"} ]).unwrap();
-        once = driver.batchedUpdates().unwrap(); twice = driver.batchedUpdates().unwrap();
-        expect(once).not.toEqual(twice); checkUpdatesLen(twice, 0, 0);
-        expect(once.clusters).toContainEqual(["123", "ADDED"]);
-        expect(once.bibliography?.entryIds).toEqual(["citekey", "added"]);
-        expect(once.bibliography?.updatedEntries).toHaveProperty("added", "ADDED");
+    test("replacing a cluster", () => {
+        pccSetup((driver, [one, two]) => {
+            // replacing #1
+            var pcc = driver.previewCitationCluster(
+                [ { id: "r1" } ],
+                [{ }, { id: two }],
+                "plain"
+            ).unwrap();
+            expect(pcc).toEqual("ONE");
+            // replacing #1, with note numbers isntead
+            pcc = driver.previewCitationCluster(
+                [ { id: "r1" } ],
+                [{ note: 1, }, { id: two, note: 5 }],
+                "plain"
+            ).unwrap();
+            expect(pcc).toEqual("ONE");
+        })
     })
-});
 
-let ibidStyle = mkStyle(
-    `
-    <choose>
-        <if position="ibid">
-            <text value="ibid" />
-        </if>
-        <else>
-            <text variable="title" />
-        </else>
-    </choose>
-    `,
-    ``,
-);
-
-// There are more extensive tests already in rust, so this is more of a smoke test.
-test("previewCitationCluster", () => {
-    withDriver({ style: ibidStyle }, driver => {
-        let one = "cluster-one";
-        let two = "cluster-two";
-        oneOneOne(driver, { title: "ONE", id: "r1" }, "cluster-one");
-        oneOneOne(driver, { title: "TWO", id: "r2" }, "cluster-two");
-        driver.setClusterOrder([{ id: one }, { id: two }]).unwrap();
-        // between the other two
-        let pcc = driver.previewCitationCluster(
-            [ { id: "r1" } ],
-            [{ id: one }, { }, { id: two }],
-            "plain"
-        ).unwrap();
-        expect(pcc).toEqual("ibid");
-        // replacing #1
-        pcc = driver.previewCitationCluster(
-            [ { id: "r1" } ],
-            [{ }, { id: two }],
-            "plain"
-        ).unwrap();
-        // replacing #1, with note numbers isntead
-        pcc = driver.previewCitationCluster(
-            [ { id: "r1" } ],
-            [{ note: 1, }, { id: two, note: 5 }],
-            "plain"
-        ).unwrap();
-        expect(pcc).toEqual("ONE");
+    test("should error when supplying unsupported output format",() => {
+        pccSetup((driver, [one, two]) => {
+            let res = driver.previewCitationCluster([{id: "r1"}], [{}], "plaintext");
+            expect(() => res.unwrap()).toThrow("Unknown output format \"plaintext\"");
+        })
     })
+
 })
-

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Driver {
 #[derive(thiserror::Error, Debug, serde::Serialize)]
 #[serde(tag = "tag", content = "content")]
 pub enum DriverError {
-    #[error("Unknown output format {0}")]
+    #[error("Unknown output format {0:?}")]
     UnknownOutputFormat(String),
     /// Never serialized as a CiteprocRsDriverError, only serialized as a CslStyleError.
     #[error("Style error: {0}")]
@@ -272,7 +272,8 @@ impl Driver {
             let preview = eng.preview_citation_cluster(
                 &cites,
                 PreviewPosition::MarkWithZeroStr(&positions),
-                SupportedFormat::from_str(format).ok(),
+                Some(SupportedFormat::from_str(format)
+                    .map_err(|()| DriverError::UnknownOutputFormat(format.to_owned()))?),
             );
             Ok(preview?)
         })


### PR DESCRIPTION
Fixes #91, which was never really a bug in the formatting code.

- add test for built_cluster_preview format-changing
    * This already passed. Turns out the code was pretty much correct anyway.
- add structure to js-tests, and add an unrecognised output format test to JS
- make previewCitationCluster fail on unknown output format
