### PR TITLE
Fix doi urls in prefix duplication, and pmids/pmcids

### DIFF
--- a/crates/citeproc/tests/data/humans/url_csl11_DOI_Affixed_HTTP_Disabled.yml
+++ b/crates/citeproc/tests/data/humans/url_csl11_DOI_Affixed_HTTP_Disabled.yml
@@ -1,0 +1,28 @@
+mode: citation
+format-options:
+  link-anchors: false
+normalise: false
+result: >-
+  prefixed https://doi.org/10.1109/5.771073 ,
+  prefixed https://doi.org/10.1109/5.771073 ,
+  prefixed https://doi.org/10.1109/5.771073
+
+input:
+  - id: a
+    doi: '10.1109/5.771073'
+  - id: ab
+    doi: 'doi:10.1109/5.771073'
+  - id: ac
+    doi: 'https://doi.org/10.1109/5.771073'
+
+csl: |
+  <?xml version="1.0" encoding="utf-8"?>
+  <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0.1" default-locale="en-US">
+    <info><id>https://cormacrelf.net/citeproc-rs/test-style</id><title>test-style</title></info>
+    <citation>
+      <layout delimiter=" , ">
+        <!-- note this is http, it will still get canonicalised to https  -->
+        <text variable="doi" prefix="prefixed http://doi.org/" />
+      </layout>
+    </citation>
+  </style>

--- a/crates/citeproc/tests/data/humans/url_csl11_DOI_Affixed_HTTP_Prefixed.yml
+++ b/crates/citeproc/tests/data/humans/url_csl11_DOI_Affixed_HTTP_Prefixed.yml
@@ -1,0 +1,27 @@
+mode: citation
+format-options:
+  link-anchors: true
+normalise: false
+result: >-
+  &lt;<a href="https://doi.org/10.1109/5.771073">https://doi.org/10.1109/5.771073</a>&gt; ,
+  &lt;<a href="https://doi.org/10.1109/5.771073">https://doi.org/10.1109/5.771073</a>&gt; ,
+  &lt;<a href="https://doi.org/10.1109/5.771073">https://doi.org/10.1109/5.771073</a>&gt;
+
+input:
+  - id: a
+    doi: '10.1109/5.771073'
+  - id: ab
+    doi: 'doi:10.1109/5.771073'
+  - id: ac
+    doi: 'https://doi.org/10.1109/5.771073'
+
+csl: |
+  <?xml version="1.0" encoding="utf-8"?>
+  <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0.1" default-locale="en-US">
+    <info><id>https://cormacrelf.net/citeproc-rs/test-style</id><title>test-style</title></info>
+    <citation>
+      <layout delimiter=" , ">
+        <text variable="doi" prefix="&lt;https://doi.org/" suffix="&gt;" />
+      </layout>
+    </citation>
+  </style>

--- a/crates/citeproc/tests/data/humans/url_csl11_PMID_Affixed_HTTP.yml
+++ b/crates/citeproc/tests/data/humans/url_csl11_PMID_Affixed_HTTP.yml
@@ -1,0 +1,33 @@
+mode: citation
+format-options:
+  link-anchors: true
+normalise: false
+result: >-
+  <a href="https://www.ncbi.nlm.nih.gov/pubmed/34684596">https://www.ncbi.nlm.nih.gov/pubmed/34684596</a> ,
+  <a href="https://www.ncbi.nlm.nih.gov/pubmed/34684596">https://www.ncbi.nlm.nih.gov/pubmed/34684596</a> ,
+  <a href="https://www.ncbi.nlm.nih.gov/pubmed/34684596">https://www.ncbi.nlm.nih.gov/pubmed/34684596</a> ,
+  <a href="https://www.ncbi.nlm.nih.gov/pubmed/34684596">https://www.ncbi.nlm.nih.gov/pubmed/34684596</a> ,
+  <a href="https://www.ncbi.nlm.nih.gov/pubmed/34684596">https://www.ncbi.nlm.nih.gov/pubmed/34684596</a>
+
+input:
+  - id: pa
+    pmid: '34684596'
+  - id: pn
+    pmid: 34684596
+  - id: pb
+    pmid: 'pmid:34684596'
+  - id: pbb
+    pmid: 'PMID:34684596'
+  - id: pc
+    pmid: 'http://www.ncbi.nlm.nih.gov/pubmed/34684596'
+
+csl: |
+  <?xml version="1.0" encoding="utf-8"?>
+  <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0.1" default-locale="en-US">
+    <info><id>https://cormacrelf.net/citeproc-rs/test-style</id><title>test-style</title></info>
+    <citation>
+      <layout delimiter=" , ">
+        <text variable="pmid" prefix="http://www.ncbi.nlm.nih.gov/pubmed/" />
+      </layout>
+    </citation>
+  </style>

--- a/crates/io/src/output/links.rs
+++ b/crates/io/src/output/links.rs
@@ -1,29 +1,115 @@
-use super::markup::{InlineElement, Link};
+use crate::String;
+use csl::{Affixes, Variable};
 use url::Url;
 
-pub trait LinkId {
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub enum Link {
+    /// handles a full valid url only
+    Url { url: Url, trailing_slash: bool },
+    /// e.g. a DOI that only puts the full url in a link.
+    /// The url is an optional addition, if we are rendering anchors.
+    Id { url: Url, id: String },
+    // TODO: allow internal linking (e.g. first-reference-note-number)
+    // Href(String),
+}
+
+impl Link {
+    fn url(url: Url, orig: &str) -> Self {
+        Self::Url {
+            url,
+            trailing_slash: orig.ends_with("/"),
+        }
+    }
+}
+
+fn trim_affixes(affixes: &Affixes, trim_end_https: fn(&str) -> Option<&str>) -> Option<Affixes> {
+    let prefix = &affixes.prefix[..];
+    let trimmed = trim_end_https(prefix);
+    trimmed.map(|p| Affixes {
+        prefix: p.into(),
+        suffix: affixes.suffix.clone(),
+    })
+}
+
+/// Returns a parsed link, and (if necessary) rewritten Affixes with e.g. https://doi.org/ removed
+///
+/// The affixes returned will be None if it was not necessary to rewrite them.
+pub fn try_link_affixed(
+    var: Variable,
+    value: &str,
+    affixes: Option<&Affixes>,
+) -> Result<Option<(Link, Option<Affixes>)>, url::ParseError> {
+    match var {
+        Variable::DOI => Doi::parse(value, affixes).map(Some),
+        Variable::PMID => Pmid::parse(value, affixes).map(Some),
+        Variable::PMCID => Pmcid::parse(value, affixes).map(Some),
+        Variable::URL => Url::parse(value).map(|url| Some((Link::url(url, value), None))),
+        _ => return Ok(None),
+    }
+}
+
+/// Same as [try_link_affixed], but logs any url parsing error.
+pub fn try_link_affixed_opt(
+    var: Variable,
+    value: &str,
+    affixes: Option<&Affixes>,
+) -> Option<(Link, Option<Affixes>)> {
+    match try_link_affixed(var, value, affixes) {
+        Ok(pair) => pair,
+        Err(e) => {
+            warn!("invalid url due to {}: {}", e, value);
+            None
+        }
+    }
+}
+
+trait LinkId {
     const LOWER: &'static str;
     const UPPER: &'static str;
     const HTTP: &'static str;
     const HTTPS: &'static str;
-    fn trim(s: &str) -> &str {
-        if s.starts_with("http") {
-            s.trim_start_matches(Self::HTTPS)
-                .trim_start_matches(Self::HTTP)
-        } else {
-            s.trim_start_matches(Self::LOWER)
-                .trim_start_matches(Self::UPPER)
-        }
+    fn trim_start(s: &str) -> &str {
+        // at most, strip one of the four, once
+        s.strip_prefix(Self::HTTPS)
+            .or(s.strip_prefix(Self::HTTP))
+            .or(s.strip_prefix(Self::LOWER))
+            .or(s.strip_prefix(Self::UPPER))
+            .unwrap_or(s)
     }
-    fn parse(s: &str) -> Result<Vec<InlineElement>, url::ParseError> {
-        let trimmed = Self::trim(s);
+    fn trim_end_https(s: &str) -> Option<&str> {
+        s.strip_suffix(Self::HTTPS).or(s.strip_suffix(Self::HTTP))
+    }
+    fn parse(
+        s: &str,
+        affixes: Option<&Affixes>,
+    ) -> Result<(Link, Option<Affixes>), url::ParseError> {
+        let trimmed_id = Self::trim_start(s);
         let url = Url::parse(Self::HTTPS)?;
-        let url = url.join(trimmed)?;
-        let link = Link::Id {
-            url,
-            id: trimmed.into(),
+        let url = url.join(trimmed_id)?;
+
+        // If we do strip `https://...` out of the affixes, then something like this would break if
+        // we turned off link_anchors:
+        //
+        //   <text prefix="&lt;https://doi.org/" variable="doi" suffix="&gt;" />
+        //
+        // So we should rewrite the id as well, to carry the prefix all the way to write_url.
+        //
+        // In a very technical sense, this is incorrect as the prefix should not normally receive
+        // the formatting that the variable content does; however, in this case, the intention is
+        // clear as we only ever add `https://....`. This will also convert any use of HTTP by
+        // *styles* to HTTPS.
+        let overridden = affixes
+            .map(|a| trim_affixes(a, Self::trim_end_https))
+            .flatten();
+        let id = if overridden.is_some() {
+            let mut id = String::new();
+            id.push_str(Self::HTTPS);
+            id.push_str(trimmed_id);
+            id
+        } else {
+            trimmed_id.into()
         };
-        Ok(vec![InlineElement::Linked(link)])
+        Ok((Link::Id { url, id }, overridden))
     }
 }
 macro_rules! linkid {

--- a/crates/io/src/output/links.rs
+++ b/crates/io/src/output/links.rs
@@ -125,14 +125,14 @@ macro_rules! linkid {
 }
 linkid!(pub Doi, "doi:", "DOI:", "http://doi.org/", "https://doi.org/");
 linkid!(
-    pub Pmcid,
+    pub Pmid,
     "pmid:",
     "PMID:",
     "http://www.ncbi.nlm.nih.gov/pubmed/",
     "https://www.ncbi.nlm.nih.gov/pubmed/"
 );
 linkid!(
-    pub Pmid,
+    pub Pmcid,
     "pmcid:",
     "PMCID:",
     "http://www.ncbi.nlm.nih.gov/pmc/articles/",

--- a/crates/io/src/output/markup/rtf.rs
+++ b/crates/io/src/output/markup/rtf.rs
@@ -294,7 +294,11 @@ mod test {
         let fmt_url = |url_str: &str, in_attr: bool| {
             let mut dest = String::new();
             let url = url::Url::parse(url_str).unwrap();
-            RtfWriter::new(&mut dest, Default::default()).write_url(&url, url_str.ends_with('/'), in_attr);
+            RtfWriter::new(&mut dest, Default::default()).write_url(
+                &url,
+                url_str.ends_with('/'),
+                in_attr,
+            );
             dest
         };
 

--- a/crates/io/src/output/mod.rs
+++ b/crates/io/src/output/mod.rs
@@ -106,6 +106,8 @@ pub enum FormatCmd {
 
 use std::hash::Hash;
 
+use self::links::Link;
+
 pub trait OutputFormat: Send + Sync + Clone + Default + PartialEq + std::fmt::Debug {
     type Input: std::fmt::Debug + DeserializeOwned + Default + Clone + Send + Sync + Eq + Hash;
     type Build: std::fmt::Debug + Default + Clone + Send + Sync + Eq;
@@ -221,9 +223,7 @@ pub trait OutputFormat: Send + Sync + Clone + Default + PartialEq + std::fmt::De
         in_bibliography: bool,
     ) -> Self::Build;
 
-    fn try_link_full(&self, full_url: &str, options: &IngestOptions) -> Self::Build;
-    fn try_link_id(&self, var: csl::Variable, id_str: &str, options: &IngestOptions)
-        -> Self::Build;
+    fn link(&self, link: Link) -> Self::Build;
 
     fn stack_preorder(&self, s: &mut String, stack: &[FormatCmd]);
     fn stack_postorder(&self, s: &mut String, stack: &[FormatCmd]);

--- a/crates/proc/src/sort/output_format.rs
+++ b/crates/proc/src/sort/output_format.rs
@@ -4,6 +4,7 @@
 //
 // Copyright © 2018 Corporation for Digital Scholarship
 
+use citeproc_io::output::links::Link;
 use citeproc_io::output::{
     micro_html::micro_html_to_string, FormatCmd, LocalizedQuotes, OutputFormat,
 };
@@ -141,19 +142,11 @@ impl OutputFormat for SortStringFormat {
         *build = options.transform_case(string, false, true, is_uppercase);
     }
 
-    fn try_link_full(&self, full_url: &str, options: &IngestOptions) -> Self::Build {
-        full_url.into()
-    }
-
-    fn try_link_id(&self, var: csl::Variable, id: &str, options: &IngestOptions) -> Self::Build {
-        use citeproc_io::output::links::*;
-        match var {
-            csl::Variable::DOI => Doi::trim(id),
-            csl::Variable::PMCID => Pmcid::trim(id),
-            csl::Variable::PMID => Pmid::trim(id),
-            csl::Variable::URL => id,
-            _ => id,
+    fn link(&self, link: Link) -> Self::Build {
+        match link {
+            Link::Url { url, .. } | Link::Id { url, .. } => {
+                smart_format!("{}", url)
+            }
         }
-        .into()
     }
 }


### PR DESCRIPTION
Fixes #127, fixes #131

- strip url prefix from prefix="... https://doi.org/" (etc)
  - internal note, simplifies the OutputFormat API to just take a `Link` and return a `Self::Build`. The list of url-ish variables didn't need to be specific to each OutputFormat implementation (we do only have two, but yeah)
- Fix PMID / PMCID confusion
- match more variants of PMID/PMCID urls
- Confirm doi prefix-stripping works with link_anchors disabled

One note here is that PubMed has started redirecting PMID urls to e.g. <https://pubmed.ncbi.nlm.nih.gov/34706787/>, so that might be a better canonical url format. But for the moment it just does what the csl 1.1 spec says.