### PR TITLE
Fix "line-spacing" attribute on <bibliography> in CSL is ignored

### DIFF
--- a/crates/citeproc/src/processor.rs
+++ b/crates/citeproc/src/processor.rs
@@ -582,7 +582,7 @@ impl Processor {
                 // TODO
                 max_offset: 0,
                 entry_spacing: bib.entry_spacing,
-                line_spacing: bib.line_spaces,
+                line_spacing: bib.line_spacing,
                 hanging_indent: bib.hanging_indent,
                 // To avoid serde derive in csl
                 second_field_align: bib.second_field_align.as_ref().map(|s| match s {

--- a/crates/csl/src/lib.rs
+++ b/crates/csl/src/lib.rs
@@ -452,9 +452,9 @@ impl FromNode for Bibliography {
             );
         }
         let layout_node = layouts[0];
-        let line_spaces = attribute_int(node, "line-spaces", 1)?;
-        if line_spaces < 1 {
-            return Err(InvalidCsl::new(node, "line-spaces must be >= 1").into());
+        let line_spacing = attribute_int(node, "line-spacing", 1)?;
+        if line_spacing < 1 {
+            return Err(InvalidCsl::new(node, "line-spacing must be >= 1").into());
         }
         let entry_spacing = attribute_int(node, "entry-spacing", 1)?;
         let sorts: Vec<_> = node.children().filter(|n| n.has_tag_name("sort")).collect();
@@ -471,7 +471,7 @@ impl FromNode for Bibliography {
             layout: Layout::from_node(&layout_node, info)?,
             hanging_indent: bool::attribute_default_val(node, "hanging-indent", info, false)?,
             second_field_align: attribute_option(node, "second-field-align", info)?,
-            line_spaces,
+            line_spacing,
             entry_spacing,
             name_inheritance: Name::from_node(&node, info)?,
             subsequent_author_substitute: attribute_option(

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -1019,7 +1019,7 @@ pub struct Bibliography {
     pub layout: Layout,
     pub hanging_indent: bool, // default is false
     pub second_field_align: Option<SecondFieldAlign>,
-    pub line_spaces: u32,   // >= 1 only. default is 1
+    pub line_spacing: u32,   // >= 1 only. default is 1
     pub entry_spacing: u32, // >= 0. default is 1
     pub name_inheritance: Name,
     pub subsequent_author_substitute: Option<SmartString>,


### PR DESCRIPTION
This fixes an issue where bibliography renders with incorrect line spacing.

Struct `style::Bibliography` used `line-spaces`, however it should be `line-spacing` according to [the spec](https://docs.citationstyles.org/en/stable/specification.html#bibliography-specific-options).
