### PR TITLE
fix external PR tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
         run: |
           mkdir -p .snapshots/branches
-          aws s3 cp s3://citeproc-rs-test-results/.snapshots/branches/$GITHUB_BASE .snapshots/branches/$GITHUB_BASE
+          S3_PREFIX='https://citeproc-rs-test-results.cormacrelf.net'
+          curl -sL "$S3_PREFIX/.snapshots/branches/$GITHUB_BASE" -o ".snapshots/branches/$GITHUB_BASE"
 
       - name: Install Rust nightly-2021-08-30
         uses: actions-rs/toolchain@v1
@@ -111,9 +112,11 @@ jobs:
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
           GITHUB_BASE: ${{ steps.branch.outputs.base }}
         run: |
-          if test -f .snapshots/current; then
-            aws s3 cp .snapshots/current s3://citeproc-rs-test-results/.snapshots/branches/$GITHUB_HEAD
-            aws s3 cp .snapshots/current s3://citeproc-rs-test-results/.snapshots/commits/$GITHUB_SHA
+          # this will not run if the secret key is missing,
+          # which happens on PRs from non-collaborators
+          if test -f .snapshots/current && test -nz "$AWS_SECRET_ACCESS_KEY"; then
+            aws s3 cp .snapshots/current "s3://citeproc-rs-test-results/.snapshots/branches/$GITHUB_HEAD"
+            aws s3 cp .snapshots/current "s3://citeproc-rs-test-results/.snapshots/commits/$GITHUB_SHA"
           fi
 
   wasm_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
           if ${{github.event_name == 'push' && 'true' || 'false'}}; then
             echo "branches/$GITHUB_HEAD" > test-results/name
 
-            # TEMPORARY: then let's write to an old PR, just for now
-            echo "1" > test-results/pr-number
+            # DEBUGGING ONLY: write to an old PR
+            # echo "1" > test-results/pr-number
           fi
 
       - name: "Upload test result artifacts (GitHub Actions)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request: {}
-  push: 
+  push:
     branches:
     - master
     - ci/*
@@ -80,6 +80,7 @@ jobs:
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
         run: |
           mkdir -p .snapshots/branches
+          mkdir -p test-results
           S3_PREFIX='https://citeproc-rs-test-results.cormacrelf.net'
           curl -sL "$S3_PREFIX/.snapshots/branches/$GITHUB_BASE" -o ".snapshots/branches/$GITHUB_BASE"
 
@@ -102,22 +103,42 @@ jobs:
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
         run: |
           cp .snapshots/current .snapshots/branches/$GITHUB_HEAD
-          cargo test-suite diff $GITHUB_BASE..$GITHUB_HEAD
-      - name: "Upload test result artifacts"
+          cargo test-suite diff $GITHUB_BASE..$GITHUB_HEAD | tee test-results/diff
+          echo $? > test-results/diff-status
+
+      - name: "Write the test-results artifact files"
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ap-southeast-2
+          PR_NUM: ${{ github.event.number }}
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
-          GITHUB_BASE: ${{ steps.branch.outputs.base }}
         run: |
-          # this will not run if the secret key is missing,
-          # which happens on PRs from non-collaborators
-          if test -f .snapshots/current && test -nz "$AWS_SECRET_ACCESS_KEY"; then
-            aws s3 cp .snapshots/current "s3://citeproc-rs-test-results/.snapshots/branches/$GITHUB_HEAD"
-            aws s3 cp .snapshots/current "s3://citeproc-rs-test-results/.snapshots/commits/$GITHUB_SHA"
+          mkdir -p test-results
+          test -f .snapshots/current && cp .snapshots/current test-results/snapshot || echo "" > test-results/snapshot
+
+          if ${{ github.event_name == 'pull_request' && 'true' || 'false'}}; then
+            echo "$PR_NUM" > test-results/pr-number
+            echo "pulls/$PR_NUM" > test-results/name
           fi
+          if ${{github.event_name == 'push' && 'true' || 'false'}}; then
+            echo "branches/$GITHUB_HEAD" > test-results/name
+
+            # TEMPORARY: then let's write to an old PR, just for now
+            echo "1" > test-results/pr-number
+          fi
+
+      - name: "Upload test result artifacts (GitHub Actions)"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: |
+            test-results/*
+          # i.e.
+          # test-results/pr-number
+          # test-results/name
+          # test-results/diff
+          # test-results/diff-status
+          # test-results/snapshot
 
   wasm_tests:
     name: "Test the WASM package"

--- a/.github/workflows/post-ci.yml
+++ b/.github/workflows/post-ci.yml
@@ -1,0 +1,153 @@
+name: CI Results
+
+# From the docs: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
+#
+# > The workflow started by the workflow_run event is able to access secrets and
+# write tokens, even if the previous workflow was not.
+#
+# So we can upload results to S3 anyway.
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+
+jobs:
+  upload_test_results:
+    name: "Upload Test Results"
+    runs-on: ubuntu-20.04
+    steps:
+
+      # https://github.community/t/pull-request-attribute-empty-in-workflow-run-event-object-for-pr-from-forked-repo/154682
+      - name: "Download artifacts from PR workflow"
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci.yml
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Read the PR number file
+        id: wf
+        run: |
+          if test -d ./test-results; then
+            cd ./test-results
+            if test -f ./pr-number; then
+              echo "::set-output name=pr_number::$(cat ./pr-number)"
+            fi
+            echo "::set-output name=snapshot_name::$(cat ./name)"
+            echo "::set-output name=found::true"
+          else
+            echo "::set-output name=found::false"
+          fi
+
+      - name: "Upload results to S3"
+        if: steps.wf.outputs.found == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-southeast-2
+          GITHUB_HEAD: ${{ steps.branch.outputs.head }}
+          GITHUB_BASE: ${{ steps.branch.outputs.base }}
+          PR_NUM: ${{ steps.wf.outputs.pr_number }}
+          SNAPSHOT_NAME: ${{ steps.wf.outputs.snapshot_name }}
+        working-directory: ./test-results
+        run: |
+          if test -f snapshot; then
+            aws s3 cp snapshot "s3://citeproc-rs-test-results/.snapshots/$SNAPSHOT_NAME"
+          fi
+
+      - name: Write message to file
+        if: steps.wf.outputs.pr_number != 0
+        id: comment_txt
+        env:
+          PR_NUM: ${{ steps.wf.outputs.pr_number }}
+          SNAPSHOT_NAME: ${{ steps.wf.outputs.snapshot_name }}
+        working-directory: ./test-results
+        run: |
+          STATUS=$(cat ./diff-status)
+          if [ "$STATUS" = "0" ]; then STATUS="success"; else STATUS="failure"; fi
+          rm -f comment.txt diff.txt
+          # remove ansi escape codes, get github markdown to do the diffing
+          perl -pe 's/\e\[[0-9;]*m(?:\e\[K)?//g' ./diff > diff.txt
+          perl -i -ne '
+          if ($inblock) {
+            # note the break out from single quoted bash string here
+            if      (s/^        '\'', crates\/.*$/```\n/m) {
+              $inblock = 0;
+            } elsif (s/^        <(.*)$/-$1/g) {
+            } elsif (s/^        >(.*)$/+$1/g) {
+            } elsif (s/^         (.*)$/ $1/) { }
+            print;
+          } elsif (s/^(regression: |failure: |newly ignored: )(.*)$/\n### $1 $2\n/) {
+            print;
+          } elsif (/improved:/) {
+            if ($improved) { s/^improved: (.*)$/##### $1/
+            } else         { s/^(improved:) (.*)$/### $1\n\n##### $2/ }
+            $improved = 1; print;
+          } elsif (/^output changed: /) {
+            if ($output_changed) { s/^output changed: (.*)$/##### $1/
+            } else               { s/^(output changed:) (.*)$/### $1\n\n##### $2/ }
+            $output_changed = 1; print;
+          } elsif (/added passing test:/) {
+            if ($added) { s/^added passing test: (.*)$/- $1/
+            } else      { s/^(added passing test): (.*)$/### $1s:\n\n- $2/ }
+            $added = 1; print;
+          } elsif (s/^    (base \(now fixed\):)/$1\n/) { # extra newline to sep any log output
+            print;
+          } elsif (s?^        Diff < left / right > :$?\n```diff?) {
+            $inblock=1;
+            print;
+          } else {
+            print unless /^        $|RUST_BACKTRACE|panicked at '\''assertion failed: `\(left == right\)/
+          }
+          ' diff.txt
+
+          URL="https://cormacrelf.github.io/citeproc-rs-test-viewer/$SNAPSHOT_NAME"
+          RES=$(< ./diff tail -n 3 | head -n 1 | perl -ne '
+            s/ *test result: (.*)$/$1/;
+            my @components = split(", ", $_);
+            my @list = ();
+            foreach (@components) {
+              push(@list, $_) unless (/^0 |^out of/);
+            }
+            print join(", ", @list)
+            ')
+
+          # too boring, i.e. only the last three lines that are always there
+          if [ "$(wc -l ./diff | awk '{print $1}')" = "3" ] && [ "$STATUS" = "success" ] && test -z "$RES"; then
+            echo "::set-output name=exists::false"
+            echo "=> skipping PR comment because diff was empty"
+            echo
+            cat diff.txt
+            exit 0
+          fi
+          echo "::set-output name=exists::true"
+
+          { echo '<details><summary>'
+            echo "Test results (<strong>${STATUS}</strong>; <a href=\"${URL}\">full results</a>): $RES"
+            echo '</summary>'; echo
+            cat diff.txt
+            echo '</details>'
+          } >> comment.txt
+
+          echo
+          echo "=> Writing comment.txt with"
+          echo
+          head -n 10 comment.txt
+
+      - name: "Comment on PR with diff"
+        if: steps.wf.outputs.pr_number != 0 && steps.comment_txt.outputs.exists == 'true'
+        uses: actions/github-script@v5
+        env:
+          PR_NUM: ${{ steps.wf.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { PR_NUM } = process.env;
+            const comment = fs.readFileSync("test-results/comment.txt", "utf8")
+            github.rest.issues.createComment({
+              issue_number: +PR_NUM,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            })


### PR DESCRIPTION
Fixes #134 

- don't error when PR submitted by non-collaborator
- post-ci workflow to add a comment on PRs with any regressions included

Example comment, from diffing some random things in my .snapshots folder. Appears from @github-actions [bot]

<details><summary>
Test results (<strong>success</strong>; <a href="https://cormacrelf.github.io/citeproc-rs-test-viewer/branches/master">full results</a>): 24 new passing tests
</summary>

### added passing tests:

- humans::intext_AuthorOnly_Title.yml
- humans::collapse_YearSuffix_Locator_Ranged.yml
- humans::collapse_YearSuffix_Prefix.yml
- humans::collapse_YearSuffix_Suffix.yml
- fixtures_local::discretionary_SingleNarrativeCitation.txt
- humans::intext_AuthorOnly_DateYearSuffix.yml
- fixtures_local::discretionary_ExampleUnauthored.txt
- humans::collapse_YearSuffix_Prefix_Ranged.yml
- humans::intext_Mixed.yml
- fixtures_local::discretionary_ExampleMultiple.txt
- humans::intext_Composite_Fail.yml
- fixtures_local::discretionary_ExampleProcess.txt
- fixtures_local::discretionary_ExampleSeveralAuthorsWithIntext.txt
- humans::intext_Composite_Fail_UsingIntextElement.yml
- humans::collapse_YearSuffix_Suffix_Ranged.yml
### improved:

##### fixtures_local::discretionary_AuthorOnly.txt
base (now fixed):


```diff
-(John Smith, 2001)
+John Smith
 (Robert Jones, 2002)
-(Book C, 2003)
-(2004, [Susan Jenkins tran.])
-(Book E, 2005, [Vincent Herbert tran.])
+Book C
+2004
+Book E
```

##### fixtures_local::discretionary_CitationNumberAuthorOnlyThenSuppressAuthor.txt
base (now fixed):

        Some(AuthorOnly)
        Some(SuppressAuthor { suppress_max: 0 })
        None

```diff
-[0] <i>[1]</i>
+[0] [NO_PRINTED_FORM]
 [1] <i>[1]</i>
 [2] <i>[2]</i>

```

</details>