### PR TITLE
Solve year-suffix / no-date interaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,12 @@ jobs:
         env:
           GITHUB_BASE: ${{ steps.branch.outputs.base }}
           GITHUB_HEAD: ${{ steps.branch.outputs.head }}
+        shell: bash
         run: |
           cp .snapshots/current .snapshots/branches/$GITHUB_HEAD
           cargo test-suite diff $GITHUB_BASE..$GITHUB_HEAD | tee test-results/diff
-          echo $? > test-results/diff-status
+          # need the first command in the pipe, $? would give us tee's status
+          echo "${PIPESTATUS[0]}" > test-results/diff-status
 
       - name: "Write the test-results artifact files"
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust nightly-2021-08-30
+      - name: install rust nightly-2021-10-07
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly-2021-08-30
+            toolchain: nightly-2021-10-07
             override: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --lib
@@ -84,10 +84,10 @@ jobs:
           S3_PREFIX='https://citeproc-rs-test-results.cormacrelf.net'
           curl -sL "$S3_PREFIX/.snapshots/branches/$GITHUB_BASE" -o ".snapshots/branches/$GITHUB_BASE"
 
-      - name: Install Rust nightly-2021-08-30
+      - name: install rust nightly-2021-10-07
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly-2021-08-30
+            toolchain: nightly-2021-10-07
             override: true
       - uses: Swatinem/rust-cache@v1
 

--- a/bindings/xcframework/build.sh
+++ b/bindings/xcframework/build.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 : "${OUTNAME:=CiteprocRs}"
 # needs PR https://github.com/rust-lang/rust/pull/87699
 # install with `rustup install $TOOLCHAIN && rustup component add rust-src --toolchain $TOOLCHAIN`
-# : "${TOOLCHAIN:=nightly-2021-08-30}"
+# : "${TOOLCHAIN:=nightly-2021-10-07}"
 : "${CONFIGURATION:=test}"
 
 export IPHONEOS_DEPLOYMENT_TARGET=13.0

--- a/bindings/xcframework/rust-toolchain.toml
+++ b/bindings/xcframework/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # needs PR https://github.com/rust-lang/rust/pull/87699
-channel = "nightly-2021-08-30"
+channel = "nightly-2021-10-07"
 profile = "minimal"
 components = [ "rust-src" ]
 targets = [

--- a/crates/citeproc/tests/data/humans/group_TextDateYearSuffix.yml
+++ b/crates/citeproc/tests/data/humans/group_TextDateYearSuffix.yml
@@ -1,0 +1,52 @@
+mode: citation
+# The prefix should show up with either the date or an explicit year-suffix.
+# But it should not show up if neither are present.
+result: >
+  Smith pfx-1999a; Smith pfx-1999b;
+  Smith pfx-2000;
+  Jones pfx-a; Jones pfx-b;
+  Cuarón
+
+input:
+  - id: smith-1999-1
+    author: [{family: "Smith"}]
+    issued: { date-parts: [[1999]]}
+  - id: smith-1999-2
+    author: [{family: "Smith"}]
+    issued: { date-parts: [[1999]]}
+  - id: smith-2000
+    author: [{family: "Smith"}]
+    issued: { date-parts: [[2000]]}
+  - id: jones-1
+    author: [{family: "Jones"}]
+  - id: jones-2
+    author: [{family: "Jones"}]
+  - id: cuarón
+    author: [{family: "Cuarón"}]
+
+clusters:
+  - id: cluster-one
+    cites:
+      - id: smith-1999-1
+      - id: smith-1999-2
+      - id: smith-2000
+      - id: jones-1
+      - id: jones-2
+      - id: cuarón
+
+csl: |
+  <style class="in-text" version="1.0.1">
+    <info><id>id</id><title /></info>
+    <citation disambiguate-add-year-suffix="true">
+      <layout delimiter="; ">
+        <group delimiter=" ">
+          <names variable="author" />
+          <group>
+            <text value="pfx-" />
+            <date variable="issued" form="numeric" date-parts="year" />
+            <text variable="year-suffix" />
+          </group>
+        </group>
+      </layout>
+    </citation>
+  </style>

--- a/crates/citeproc/tests/data/humans/group_YearSuffixExplicit.yml
+++ b/crates/citeproc/tests/data/humans/group_YearSuffixExplicit.yml
@@ -1,0 +1,34 @@
+mode: citation
+# the space should not show up if the year-suffix doesn't
+result: (Smith a; Smith b; Jones; Smith c)
+input:
+  - id: smith-1999-1
+    author: [{family: "Smith"}]
+  - id: smith-1999-2
+    author: [{family: "Smith"}]
+  - id: smith-1999-3
+    author: [{family: "Jones"}]
+  - id: smith-2000
+    author: [{family: "Smith"}]
+clusters:
+  - id: cluster-one
+    cites:
+      - id: smith-1999-1
+      - id: smith-1999-2
+      - id: smith-1999-3
+      - id: smith-2000
+csl: |
+  <style class="in-text" version="1.0.1">
+    <info><id>id</id><title /></info>
+    <citation disambiguate-add-year-suffix="true">
+      <layout delimiter="; " prefix="(" suffix=")">
+        <group delimiter=" ">
+          <names variable="author" />
+          <group>
+            <text value=" " />
+            <text variable="year-suffix" />
+          </group>
+        </group>
+      </layout>
+    </citation>
+  </style>

--- a/crates/citeproc/tests/data/humans/group_YearSuffixExplicit.yml
+++ b/crates/citeproc/tests/data/humans/group_YearSuffixExplicit.yml
@@ -6,7 +6,7 @@ input:
     author: [{family: "Smith"}]
   - id: smith-1999-2
     author: [{family: "Smith"}]
-  - id: smith-1999-3
+  - id: jones
     author: [{family: "Jones"}]
   - id: smith-2000
     author: [{family: "Smith"}]
@@ -15,7 +15,7 @@ clusters:
     cites:
       - id: smith-1999-1
       - id: smith-1999-2
-      - id: smith-1999-3
+      - id: jones
       - id: smith-2000
 csl: |
   <style class="in-text" version="1.0.1">

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -1019,7 +1019,7 @@ pub struct Bibliography {
     pub layout: Layout,
     pub hanging_indent: bool, // default is false
     pub second_field_align: Option<SecondFieldAlign>,
-    pub line_spacing: u32,   // >= 1 only. default is 1
+    pub line_spacing: u32,  // >= 1 only. default is 1
     pub entry_spacing: u32, // >= 0. default is 1
     pub name_inheritance: Name,
     pub subsequent_author_substitute: Option<SmartString>,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -983,6 +983,7 @@ fn ir_gen0(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
         .citation
         .intermediate(db, &mut state, &ctx, &mut arena);
     let irgen = IrGen::new(IrTree::new(root, arena), state, false);
+    log::debug!("ir_gen0: {:?}", irgen);
     Arc::new(irgen)
 }
 
@@ -1101,6 +1102,7 @@ fn ir_gen2_add_given_name(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     irgen.update_is_ambiguous(db, &ctx);
     irgen.disambiguate_add_names(db, &mut ctx);
     irgen.disambiguate_add_given_name(db, &mut ctx);
+    log::debug!("ir_gen2_add_given_name: {:?}", irgen.deref());
     irgen.into_arc()
 }
 
@@ -1116,6 +1118,7 @@ fn ir_fully_disambiguated(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let mut irgen = IrGenCow::new(db.ir_gen2_add_given_name(id));
     irgen.disambiguate_add_year_suffix(db, &mut ctx);
     irgen.disambiguate_conditionals(db, &mut ctx);
+    log::debug!("ir_fully_disambiguated: {:?}", irgen.deref());
     irgen.into_arc()
 }
 

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -912,6 +912,7 @@ fn disambiguate_add_year_suffix(tree: &mut IrTree, ctx: &CiteContext<'_, Markup>
         break;
     }
     if added_suffix {
+        tree.recompute_group_vars();
         return;
     }
 
@@ -919,6 +920,7 @@ fn disambiguate_add_year_suffix(tree: &mut IrTree, ctx: &CiteContext<'_, Markup>
     for yid in hooks {
         let (ys, _) = get_ys_mut(yid, &mut tree.arena);
         let sum: IrSum<Markup> = match &ys.hook {
+            // This produces GroupVars::Important
             YearSuffixHook::Plain => ys.hook.render(ctx, suffix),
             _ => continue,
         };
@@ -1117,6 +1119,7 @@ fn ir_fully_disambiguated(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     // Start with the given names done.
     let mut irgen = IrGenCow::new(db.ir_gen2_add_given_name(id));
     irgen.disambiguate_add_year_suffix(db, &mut ctx);
+    log::debug!("ir_add_year_suffix: {}", irgen.deref().tree);
     irgen.disambiguate_conditionals(db, &mut ctx);
     log::debug!("ir_fully_disambiguated: {}", irgen.deref().tree);
     irgen.into_arc()

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -983,7 +983,7 @@ fn ir_gen0(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
         .citation
         .intermediate(db, &mut state, &ctx, &mut arena);
     let irgen = IrGen::new(IrTree::new(root, arena), state, false);
-    log::debug!("ir_gen0: {:?}", irgen);
+    log::debug!("ir_gen0: {}", irgen.tree);
     Arc::new(irgen)
 }
 
@@ -1102,7 +1102,7 @@ fn ir_gen2_add_given_name(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     irgen.update_is_ambiguous(db, &ctx);
     irgen.disambiguate_add_names(db, &mut ctx);
     irgen.disambiguate_add_given_name(db, &mut ctx);
-    log::debug!("ir_gen2_add_given_name: {:?}", irgen.deref());
+    log::debug!("ir_gen2_add_given_name: {}", irgen.deref().tree);
     irgen.into_arc()
 }
 
@@ -1118,7 +1118,7 @@ fn ir_fully_disambiguated(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let mut irgen = IrGenCow::new(db.ir_gen2_add_given_name(id));
     irgen.disambiguate_add_year_suffix(db, &mut ctx);
     irgen.disambiguate_conditionals(db, &mut ctx);
-    log::debug!("ir_fully_disambiguated: {:?}", irgen.deref());
+    log::debug!("ir_fully_disambiguated: {}", irgen.deref().tree);
     irgen.into_arc()
 }
 

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -517,9 +517,9 @@ fn refs_accepting_cite(
         })
         .collect();
 
-    if log_enabled!(log::Level::Warn) && !ret.contains(ref_id) {
+    if !ret.contains(ref_id) {
         let dfa = db.ref_dfa(ref_id.clone()).unwrap();
-        warn!(
+        error!(
             "{:?}: own reference {} did not match during pass {:?}:\n{}\n{:?}",
             cite_id,
             ref_id,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -1377,14 +1377,17 @@ fn bib_item_gen0_acontextual(
             // need to only supply the first appearing explicit one, or the first appearing implicit one.
             // TODO: comply with the spec where "hook in cite == explicit => no implicit in bib" and "vice
             // versa"
+            log::debug!("bib_ir_gen0: {}", tree);
             if let Some(suffix) = db.year_suffix_for(ref_id.clone()) {
                 ctx.disamb_pass = Some(DisambPass::AddYearSuffix(suffix));
                 disambiguate_add_year_suffix(&mut tree, &ctx, suffix);
+                log::debug!("bib_ir add_year_suffix: {}", tree);
             }
 
             if first_cite_used_disambiguate_true(db, ref_id.clone()) {
                 ctx.disamb_pass = Some(DisambPass::Conditionals);
                 disambiguate_true(db, &mut tree, &mut state, &ctx);
+                log::debug!("bib_ir disambiguate_true: {}", tree);
             }
 
             if bib.second_field_align == Some(csl::SecondFieldAlign::Flush) {

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -120,7 +120,7 @@ impl Disambiguation<Markup> for Element {
                                 let gv = GroupVars::rendered_if(edge.is_some());
                                 return (RefIR::Edge(edge), gv);
                             } else {
-                                return (RefIR::Edge(None), GroupVars::Plain);
+                                return (RefIR::Edge(None), GroupVars::Missing);
                             }
                         }
                         StandardVariable::Ordinary(v @ Variable::CitationLabel) => {

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -187,7 +187,16 @@ impl Disambiguation<Markup> for Element {
                         .map(|x| fmt.output_in_context(x, stack, None))
                         .map(EdgeData::Output)
                         .map(|label| label);
-                    (RefIR::Edge(content), GroupVars::new())
+                    let gv = if let csl::TextTermSelector::Simple(csl::SimpleTermSelector::Misc(
+                        csl::MiscTerm::NoDate,
+                        _,
+                    )) = term_selector
+                    {
+                        GroupVars::Important // Make this Important (same for element.rs) to have no-date act as a variable
+                    } else {
+                        GroupVars::Plain
+                    };
+                    (RefIR::Edge(content), gv)
                 }
                 TextSource::Macro(ref name) => {
                     let macro_elements = ctx

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -34,11 +34,12 @@ impl Disambiguation<Markup> for Group {
         // TODO: handle GroupVars
         let stack = self.formatting.map(|mine| stack.override_with(mine));
         let els = &self.elements;
-        let (seq, group_vars) = ref_sequence(
+        ref_sequence(
             db,
             state,
             ctx,
             els,
+            // implicit_conditional
             true,
             stack,
             Some(&|| RefIrSeq {
@@ -46,8 +47,7 @@ impl Disambiguation<Markup> for Group {
                 affixes: self.affixes.clone(),
                 ..Default::default()
             }),
-        );
-        group_vars.implicit_conditional(seq)
+        )
     }
 }
 
@@ -220,7 +220,7 @@ impl Disambiguation<Markup> for Element {
                         }),
                     );
                     state.pop_macro(name);
-                    group_vars.implicit_conditional(seq)
+                    (seq, group_vars)
                 }
             },
             Element::Label(label) => {

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -238,9 +238,7 @@ pub trait Disambiguation<O: OutputFormat = Markup> {
         _ctx: &RefContext<O>,
         _state: &mut IrState,
         _stack: Formatting,
-    ) -> (RefIR, GroupVars) {
-        unimplemented!()
-    }
+    ) -> (RefIR, GroupVars);
 }
 
 /// Creates a Dfa that will match any cite that could have been made by a particular reference.

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -198,7 +198,15 @@ where
                         let content = renderer
                             .text_term(text, term_selector, plural)
                             .map(CiteEdgeData::Term);
-                        arena.new_node((IR::Rendered(content), GroupVars::new()))
+                        let gv = if let csl::TextTermSelector::Simple(
+                            csl::SimpleTermSelector::Misc(csl::MiscTerm::NoDate, _),
+                        ) = term_selector
+                        {
+                            GroupVars::Important
+                        } else {
+                            GroupVars::Plain
+                        };
+                        arena.new_node((IR::Rendered(content), gv))
                     }
                 }
             }

--- a/crates/proc/src/group.rs
+++ b/crates/proc/src/group.rs
@@ -167,20 +167,16 @@ impl GroupVars {
     }
 
     #[inline]
-    pub fn implicit_conditional<T: Default + PartialEq + std::fmt::Debug>(
-        self,
-        ir: T,
-    ) -> (T, Self) {
+    pub fn implicit_conditional<T: Default>(self, ir: T, is_empty: bool) -> (T, Self) {
         // self here is children_gvs.fold(Plain, neighbour).
-        let def = T::default();
-
         if self == Missing {
             // if it's missing, we replace any (clearly Plain-only) nodes we wrote into the seq,
             // with the default for the seq type.
             //
             // Note that this does not affect UnresolvedMissing. That output is kept.
-            (def, GroupVars::Missing)
-        } else if ir == def {
+            // Note also that the seq type does not necesssarily store its child nodes inline.
+            (T::default(), GroupVars::Missing)
+        } else if is_empty {
             // if it's empty (== default implies empty), then we treat the seq node as Plain for
             // the purposes of groups higher up.
             (ir, GroupVars::Plain)

--- a/crates/proc/src/group.rs
+++ b/crates/proc/src/group.rs
@@ -153,8 +153,7 @@ impl GroupVars {
     #[inline]
     pub fn promote_plain(self) -> Self {
         match self {
-            // We need to not do this!????
-            // Plain | Important => Important,
+            Plain | Important => Important,
             _ => self,
         }
     }

--- a/crates/proc/src/group.rs
+++ b/crates/proc/src/group.rs
@@ -153,7 +153,8 @@ impl GroupVars {
     #[inline]
     pub fn promote_plain(self) -> Self {
         match self {
-            Plain | Important => Important,
+            // We need to not do this!????
+            // Plain | Important => Important,
             _ => self,
         }
     }

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -32,11 +32,12 @@ where
 
     for el in els {
         let child = el.intermediate(db, state, ctx, arena);
-        let (ref _ch_ir, ch_gv) = *arena.get(child).unwrap().get();
-        // if *ch_ir == IR::Rendered(None) {
-        //     dropped_gv = dropped_gv.neighbour(ch_gv);
-        // }
-        self_node.append(child, arena);
+        let (ref ch_ir, ch_gv) = *arena.get(child).unwrap().get();
+        if *ch_ir == IR::Rendered(None) {
+            dropped_gv = dropped_gv.neighbour(ch_gv);
+        } else {
+            self_node.append(child, arena);
+        }
         overall_gv = overall_gv.neighbour(ch_gv)
     }
 

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -21,8 +21,8 @@ where
     O: OutputFormat,
     I: OutputFormat,
 {
-    let mut overall_gv = GroupVars::new();
-    let mut dropped_gv = GroupVars::new();
+    let mut overall_gv = GroupVars::Plain;
+    let mut dropped_gv = GroupVars::Plain;
 
     // We will edit this later if it turns out it has content & isn't discarded
     let self_node = arena.new_node((IR::Rendered(None), GroupVars::Plain));
@@ -32,18 +32,12 @@ where
 
     for el in els {
         let child = el.intermediate(db, state, ctx, arena);
-        let ch = arena.get(child).unwrap().get();
-        let gv = ch.1;
-        match ch.0 {
-            IR::Rendered(None) => {
-                dropped_gv = dropped_gv.neighbour(gv);
-                overall_gv = overall_gv.neighbour(gv);
-            }
-            _ => {
-                self_node.append(child, arena);
-                overall_gv = overall_gv.neighbour(gv)
-            }
-        }
+        let (ref _ch_ir, ch_gv) = *arena.get(child).unwrap().get();
+        // if *ch_ir == IR::Rendered(None) {
+        //     dropped_gv = dropped_gv.neighbour(ch_gv);
+        // }
+        self_node.append(child, arena);
+        overall_gv = overall_gv.neighbour(ch_gv)
     }
 
     let ir = if self_node.children(arena).next().is_none() {

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -7,6 +7,7 @@
 use crate::prelude::*;
 use citeproc_io::output::markup::Markup;
 use citeproc_io::output::LocalizedQuotes;
+use core::fmt;
 use csl::{Affixes, Choose, DateVariable, Formatting, GivenNameDisambiguationRule, TextElement};
 use csl::{NumberVariable, StandardVariable, Variable};
 
@@ -81,7 +82,7 @@ impl<O: OutputFormat> std::fmt::Display for IR<O> {
 /// # Disambiguation and group_vars
 ///
 /// IrSeq needs to hold things
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[derive(Default, PartialEq, Eq, Clone)]
 pub struct IrSeq {
     pub formatting: Option<Formatting>,
     pub affixes: Option<Affixes>,
@@ -93,6 +94,54 @@ pub struct IrSeq {
     pub dropped_gv: Option<GroupVars>,
     pub should_inherit_delim: bool,
     pub is_layout: bool,
+}
+
+impl fmt::Debug for IrSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            formatting,
+            affixes,
+            delimiter,
+            display,
+            quotes,
+            text_case,
+            dropped_gv,
+            should_inherit_delim,
+            is_layout,
+        } = self;
+        let mut f = f.debug_struct("IrSeq");
+        if formatting.is_some() {
+            f.field("formatting", &formatting);
+        }
+        if affixes.is_some() {
+            f.field("affixes", &affixes);
+        }
+        if delimiter.is_some() {
+            f.field("delimiter", &delimiter);
+        }
+        if display.is_some() {
+            f.field("display", &display);
+        }
+        if quotes.is_some() {
+            f.field("quotes", &quotes);
+        }
+        if quotes.is_some() {
+            f.field("quotes", &quotes);
+        }
+        if *text_case != TextCase::None {
+            f.field("text_case", &text_case);
+        }
+        if dropped_gv.is_some() {
+            f.field("dropped_gv", &dropped_gv);
+        }
+        if *should_inherit_delim {
+            f.field("should_inherit_delim", &should_inherit_delim);
+        }
+        if *is_layout {
+            f.field("is_layout", &is_layout);
+        }
+        f.finish()
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -424,7 +424,7 @@ impl IrSeq {
                 let gv = child.get_node().unwrap().get().1;
                 acc.neighbour(gv)
             })
-            // .unconditional()
+            .unconditional()
     }
     pub(crate) fn overall_group_vars<O: OutputFormat>(
         dropped_gv: Option<GroupVars>,

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -278,7 +278,7 @@ impl<'a, O: OutputFormat> IrTreeMut<'a, O> {
                     None
                 } else if let (Some(first), Some(second)) = first_two {
                     match self.arena.get(second).unwrap().get() {
-                        (IR::YearSuffix(_), GroupVars::Unresolved) if has_explicit => {
+                        (IR::YearSuffix(_), GroupVars::UnresolvedImportant) if has_explicit => {
                             self.with_node(first, |f| f.suppress_first_year(has_explicit))
                         }
                         (IR::YearSuffix(_), GroupVars::Important)

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -533,6 +533,8 @@ impl<'c, O: OutputFormat> NameIR<O> {
         Some(rendered)
     }
 
+    /// This must match the behaviour of Names::ref_ir and the stuff it adds to the Nfa
+    /// graph.
     pub(crate) fn rendered_ntbs_to_node(
         rendered_ntbs: Vec<O::Build>,
         arena: &mut IrArena<O>,

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -502,8 +502,9 @@ impl<'a, O: OutputFormat> StyleWalker for SortingWalker<'a, O> {
             }
         }
         let out = output.unwrap_or_default();
+        let is_empty = out.is_empty();
         match fold_type {
-            WalkerFoldType::Group(_g) => gv_acc.implicit_conditional(out),
+            WalkerFoldType::Group(_g) => gv_acc.implicit_conditional(out, is_empty),
             _ => (out, gv_acc),
         }
     }

--- a/crates/proc/src/tree.rs
+++ b/crates/proc/src/tree.rs
@@ -149,7 +149,7 @@ impl<'a, O: OutputFormat> fmt::Display for IrTreeRef<'a, O> {
         ) -> fmt::Result {
             let pair = arena.get(node).unwrap().get();
             for _ in 0..indent {
-                write!(f, "    ")?;
+                write!(f, "  ")?;
             }
             writeln!(f, " - [{:?}] {}", pair.1, pair.0)?;
             node.children(arena)
@@ -170,7 +170,7 @@ impl<'a, O: OutputFormat> fmt::Debug for IrTreeRef<'a, O> {
         ) -> fmt::Result {
             let pair = arena.get(node).unwrap().get();
             for _ in 0..indent {
-                write!(f, "    ")?;
+                write!(f, "  ")?;
             }
             writeln!(f, " - [{:?}] {:?}", pair.1, pair.0)?;
             node.children(arena)

--- a/crates/proc/src/tree.rs
+++ b/crates/proc/src/tree.rs
@@ -1,6 +1,6 @@
-use indextree::Arena;
-
 use crate::prelude::*;
+use core::fmt;
+use indextree::Arena;
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct IrTree<O: OutputFormat = Markup> {
@@ -56,16 +56,21 @@ impl<'a, O: OutputFormat> IrTreeRef<'a, O> {
     }
 }
 
-impl<O: OutputFormat> std::fmt::Display for IrTree<O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<O: OutputFormat> fmt::Display for IrTree<O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.tree_ref().fmt(f)
     }
 }
 
-impl<O: OutputFormat> std::fmt::Debug for IrTree<O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<O: OutputFormat> fmt::Debug for IrTree<O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.tree_ref().fmt(f)
-        // <IrTreeRef<'_, _> as std::fmt::Debug>::fmt(&self.as_reference(), f)
+    }
+}
+
+impl<O: OutputFormat> fmt::Debug for IrTreeMut<'_, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <IrTreeRef<'_, _> as fmt::Debug>::fmt(&self.as_ref(), f)
     }
 }
 
@@ -134,14 +139,14 @@ impl<'a, O: OutputFormat> IrTreeMut<'a, O> {
     }
 }
 
-impl<'a, O: OutputFormat> std::fmt::Display for IrTreeRef<'a, O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a, O: OutputFormat> fmt::Display for IrTreeRef<'a, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn go<O2: OutputFormat>(
             indent: u32,
             node: NodeId,
             arena: &IrArena<O2>,
-            f: &mut std::fmt::Formatter<'_>,
-        ) -> std::fmt::Result {
+            f: &mut fmt::Formatter<'_>,
+        ) -> fmt::Result {
             let pair = arena.get(node).unwrap().get();
             for _ in 0..indent {
                 write!(f, "    ")?;
@@ -155,14 +160,14 @@ impl<'a, O: OutputFormat> std::fmt::Display for IrTreeRef<'a, O> {
     }
 }
 
-impl<'a, O: OutputFormat> std::fmt::Debug for IrTreeRef<'a, O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a, O: OutputFormat> fmt::Debug for IrTreeRef<'a, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn go<O2: OutputFormat>(
             indent: u32,
             node: NodeId,
             arena: &IrArena<O2>,
-            f: &mut std::fmt::Formatter<'_>,
-        ) -> std::fmt::Result {
+            f: &mut fmt::Formatter<'_>,
+        ) -> fmt::Result {
             let pair = arena.get(node).unwrap().get();
             for _ in 0..indent {
                 write!(f, "    ")?;

--- a/crates/proc/src/tree.rs
+++ b/crates/proc/src/tree.rs
@@ -290,11 +290,13 @@ impl<'a, O: OutputFormat> IrTreeMut<'a, O> {
         }
         // Reverse, such that descendants are recalculated first
         for (seq_node, dropped_gv) in queue.into_iter().rev() {
-            // let data = arena.get_mut(node).unwrap().get_mut();
             let seq_tree = self.tree_at_node(seq_node);
-            if let Some(force) = IrSeq::overall_group_vars(dropped_gv, seq_tree) {
-                self.arena.get_mut(seq_node).unwrap().get_mut().1 = force;
+            let force = IrSeq::overall_group_vars(dropped_gv, seq_tree);
+            let existing = self.arena.get(seq_node).unwrap().get().1;
+            if existing != force {
+                log::debug!("recompute rewriting gv to {:?} {}", force, seq_tree);
             }
+            self.arena.get_mut(seq_node).unwrap().get_mut().1 = force;
         }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/andras-simonyi/citeproc-el/issues/70#issuecomment-977145690

This makes the "no date" term behave like a variable for group suppression. It also makes the GroupVars code work less by accident and more on purpose.