### PR TITLE
reimplement name parsing

### DIFF
--- a/crates/io/src/names.rs
+++ b/crates/io/src/names.rs
@@ -4,6 +4,7 @@
 //
 // Copyright © 2018 Corporation for Digital Scholarship
 
+use crate::csl_json::RelaxedBool;
 use crate::{lazy, String};
 
 #[derive(Default, Debug, Deserialize, Clone)]
@@ -16,8 +17,7 @@ struct PersonNameInput {
     pub suffix: Option<String>,
     #[serde(default)]
     pub static_particles: bool,
-    // TODO: support "string", "number", "boolean"
-    #[serde(default)]
+    #[serde(default, deserialize_with = "RelaxedBool::deserialize_bool")]
     pub comma_suffix: bool,
 }
 

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -1306,11 +1306,11 @@ mod ord {
 
 /// we usually want to append a space to a non-dropping particle
 ///
-///     "von" + "Crumb" = "von Crumb"
+/// "von" + "Crumb" = "von Crumb"
 ///
 /// but not always; not when we have an apostrophe:
 ///
-///     "d'" + "Angelo" = "d'Angelo"
+/// "d'" + "Angelo" = "d'Angelo"
 ///
 /// see io/src/names.rs split_nondrop_family for the protocol for forcing the ndp to have a space
 /// (input { family: "d' Lastname" } and the space will be preserved).

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -1304,9 +1304,19 @@ mod ord {
     static NON_LATIN_SORT_SHORT: SortOrdering = &[&[Family]];
 }
 
+/// we usually want to append a space to a non-dropping particle
+///
+///     "von" + "Crumb" = "von Crumb"
+///
+/// but not always; not when we have an apostrophe:
+///
+///     "d'" + "Angelo" = "d'Angelo"
+///
+/// see io/src/names.rs split_nondrop_family for the protocol for forcing the ndp to have a space
+/// (input { family: "d' Lastname" } and the space will be preserved).
+///
 fn dp_should_append_space(s: &str) -> bool {
-    !s.chars()
-        .rev()
-        .nth(0)
-        .map_or(true, |last| last == '\u{2019}' || last == '-')
+    !s.chars().rev().nth(0).map_or(true, |last| {
+        matches!(last, '\u{2019}' | '\u{2018}' | '-' | '\'')
+    })
 }


### PR DESCRIPTION
This used to use code from citeproc-js, licensed under the Common Public Attribution License, so compliant users of citeproc-rs had to credit Frank, for the small amount of code here and nothing else. It's been a year or two since I've been over it, so I deleted the parts I took, and wrote it again from first principles. It turned out a little bit simpler in general, using just straight ^ and $-based regexes with repetition for given names and last names, rather than the one-particle-at-a-time + given-names-get-reversed strategy of Frank's version.

Also adds support for the using strings and numbers as fuzzy JS-style booleans on the `static-particles` JSON input.