### PR TITLE
previewCitationCluster => previewCluster

### DIFF
--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -473,8 +473,8 @@ it, before confirming the change.
 ```javascript
 let cluster = { cites: [ { id: "citekey", locator: "45" }, { ... } ] };
 let positions = [ ... before, { note: 34 }, ... after ];
-let preview = driver.previewCitationCluster(cluster, positions).unwrap();
-let plainPreview = driver.previewCitationCluster(cluster, positions, "plain").unwrap();
+let preview = driver.previewCluster(cluster, positions).unwrap();
+let plainPreview = driver.previewCluster(cluster, positions, "plain").unwrap();
 ```
 
 The cluster argument is just a cluster, without an `id` field, since it's
@@ -657,9 +657,9 @@ Both of these methods will require throwing out almost all cached computation,
 so use sparingly.
 
 If you need to render a preview in a different format, there is an argument on
-`previewCitationCluster` for doing just that. It does not throw out all the
+`previewCluster` for doing just that. It does not throw out all the
 computation. `citeproc-rs`' disambiguation procedures do take formatting into
 account, so `<i>Title</i>` can be distinct from `<b>Title</b>` in HTML and RTF,
 but not if the whole driver's output format is `"plain"`, since they both look
-identical in plain text. `previewCitationCluster` will simply translate the
-formatting into another format, without re-computing all the disambiguation.
+identical in plain text. `previewCluster` will simply translate the formatting
+into another format, without re-computing all the disambiguation.

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -471,14 +471,15 @@ Sometimes, a user wants to see how a cluster will look while they are editing
 it, before confirming the change.
 
 ```javascript
-let cites = [ { id: "citekey", locator: "45" }, { ... } ];
+let cluster = { cites: [ { id: "citekey", locator: "45" }, { ... } ] };
 let positions = [ ... before, { note: 34 }, ... after ];
-let preview = driver.previewCitationCluster(cites, positions, "html").unwrap();
+let preview = driver.previewCitationCluster(cluster, positions).unwrap();
+let plainPreview = driver.previewCitationCluster(cluster, positions, "plain").unwrap();
 ```
 
-The format argument is like the format passed to `Driver.new`: one of `"html"`,
-`"rtf"` or `"plain"`. The driver will use that instead of its normal output
-format.
+The cluster argument is just a cluster, without an `id` field, since it's
+ephemeral. The lack of `id` field is reflected in the `positions` argument as
+well.
 
 The positions array is exactly like a call to `setClusterOrder`, except exactly 
 one of the positions omits the id field. This could either:
@@ -491,6 +492,10 @@ If you passed only one position, it would be like previewing an operation like
 mean you would never see "ibid" in a preview.** So for maximum utility, 
 assemble the positions array as you would a call to `setClusterOrder` with 
 exactly the operation you're previewing applied.
+
+The format argument is optional, and works like the format passed to
+`Driver.new`: one of `"html"`, `"rtf"` or `"plain"`. The driver will use that
+instead of its normal output format.
 
 
 ### `AuthorOnly`, `SuppressAuthor` & `Composite`

--- a/crates/wasm/js-tests/node/index.test.ts
+++ b/crates/wasm/js-tests/node/index.test.ts
@@ -192,7 +192,7 @@ describe("batchedUpdates", () => {
 
 });
 
-describe("previewCitationCluster", () => {
+describe("previewCluster", () => {
 
     let ibidStyle = mkNoteStyle(
         `
@@ -223,7 +223,7 @@ describe("previewCitationCluster", () => {
     test("between two other clusters", () => {
         pccSetup((driver, [one, two]) => {
             // between the other two
-            let pcc = driver.previewCitationCluster(
+            let pcc = driver.previewCluster(
                 { cites: [{ id: "r1" }] },
                 [{ id: one }, {}, { id: two }],
                 "plain"
@@ -235,14 +235,14 @@ describe("previewCitationCluster", () => {
     test("replacing a cluster", () => {
         pccSetup((driver, [one, two]) => {
             // replacing #1
-            var pcc = driver.previewCitationCluster(
+            var pcc = driver.previewCluster(
                 { cites: [{ id: "r1" }] },
                 [{}, { id: two }],
                 "plain"
             ).unwrap();
             expect(pcc).toEqual("ONE");
             // replacing #1, with note numbers isntead
-            pcc = driver.previewCitationCluster(
+            pcc = driver.previewCluster(
                 { cites: [{ id: "r1" }] },
                 [{ note: 1, }, { id: two, note: 5 }],
                 "plain"
@@ -253,14 +253,14 @@ describe("previewCitationCluster", () => {
 
     test("should error when supplying unsupported output format", () => {
         pccSetup((driver) => {
-            let res = driver.previewCitationCluster({ cites: [{ id: "r1" }] }, [{}], "plaintext");
+            let res = driver.previewCluster({ cites: [{ id: "r1" }] }, [{}], "plaintext");
             expect(() => res.unwrap()).toThrow("Unknown output format \"plaintext\"");
         })
     });
 
     test("should allow omitting the format argument", () => {
         pccSetup((driver, [_, two]) => {
-            let res = driver.previewCitationCluster(
+            let res = driver.previewCluster(
                 { cites: [{ id: "r1" }] },
                 [{ note: 1 }, { id: two, note: 5 }]
             ).unwrap();
@@ -274,7 +274,7 @@ describe("previewCitationCluster", () => {
             driver.insertReference(
                 { title: "ONE", id: "r1", type: "book", author: [{ family: "Smith" }] }
             ).unwrap();
-            let res = driver.previewCitationCluster(
+            let res = driver.previewCluster(
                 { cites: [{ id: "r1" }], mode: "Composite", infix: ", whose book" },
                 [{ note: 1 }, { id: two, note: 5 }]
             ).unwrap();

--- a/crates/wasm/js-tests/node/index.test.ts
+++ b/crates/wasm/js-tests/node/index.test.ts
@@ -214,7 +214,7 @@ describe("previewCitationCluster", () => {
         pccSetup((driver, [one, two]) => {
             // between the other two
             let pcc = driver.previewCitationCluster(
-                [{ id: "r1" }],
+                { cites: [{ id: "r1" }] },
                 [{ id: one }, {}, { id: two }],
                 "plain"
             ).unwrap();
@@ -226,14 +226,14 @@ describe("previewCitationCluster", () => {
         pccSetup((driver, [one, two]) => {
             // replacing #1
             var pcc = driver.previewCitationCluster(
-                [{ id: "r1" }],
+                { cites: [{ id: "r1" }] },
                 [{}, { id: two }],
                 "plain"
             ).unwrap();
             expect(pcc).toEqual("ONE");
             // replacing #1, with note numbers isntead
             pcc = driver.previewCitationCluster(
-                [{ id: "r1" }],
+                { cites: [{ id: "r1" }] },
                 [{ note: 1, }, { id: two, note: 5 }],
                 "plain"
             ).unwrap();
@@ -243,7 +243,8 @@ describe("previewCitationCluster", () => {
 
     test("should error when supplying unsupported output format", () => {
         pccSetup((driver, [one, two]) => {
-            let res = driver.previewCitationCluster([{ id: "r1" }], [{}], "plaintext");
+            let res = driver.previewCitationCluster(
+                { cites: [{ id: "r1" }] }, [{}], "plaintext");
             expect(() => res.unwrap()).toThrow("Unknown output format \"plaintext\"");
         })
     })

--- a/crates/wasm/js-tests/node/index.test.ts
+++ b/crates/wasm/js-tests/node/index.test.ts
@@ -282,6 +282,16 @@ describe("previewCluster", () => {
         })
     });
 
+    test("should also work via deprecated previewCitationCluster(cites: Cite[], ...)", () => {
+        pccSetup((driver, [_, two]) => {
+            let res = driver.previewCitationCluster(
+                [{ id: "r1" }],
+                [{ note: 1 }, { id: two, note: 5 }]
+            ).unwrap();
+            expect(res).toEqual("ONE");
+        })
+    });
+
 });
 
 describe("AuthorOnly and friends", () => {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -534,7 +534,7 @@ interface InitOptions {
     localeOverride?: string,
 
     /** Disables sorting in the bibliography; items appear in cited order. */
-    bibliographyNoSort?: bool,
+    bibliographyNoSort?: boolean,
 }
 
 /** This interface lets citeproc retrieve locales or modules asynchronously,
@@ -585,7 +585,7 @@ export type Cluster = {
     cites: Cite[];
 } & ClusterMode;
 
-export type PreviewCluster {
+export type PreviewCluster = {
     cites: Cite[];
 } & ClusterMode;
 
@@ -732,11 +732,11 @@ interface WasmResult<T> {
     is_ok(): boolean;
     is_err(): boolean;
     /** If this is an error, returns the default value. */
-    unwrap_or(default: T): T;
+    unwrap_or(defaultValue: T): T;
     /** If this is Ok, returns f(ok_val), else returns Err unmodified. */
     map<R>(f: (t: T) => R): WasmResult<T>;
     /** If this is Ok, returns f(ok_val), else returns the default value. */
-    map_or<R>(default: R, f: (t: T) => R): R;
+    map_or<R>(defaultValue: R, f: (t: T) => R): R;
 }
 "#;
 
@@ -779,11 +779,11 @@ interface IndependentMeta {
     /** A list of languages for which a locale override was specified.
       * Does not include the language-less final override. */
     localeOverrides: string[],
-    hasBibliography: bool,
+    hasBibliography: boolean,
 }
 interface StyleMeta {
     info: StyleInfo,
-    features: { [feature: string]: bool },
+    features: { [feature: string]: boolean },
     defaultLocale: string,
     /** May be absent on a dependent style */
     class?: "in-text" | "note",


### PR DESCRIPTION
Fixes #119

The overall effect of these commits is to

1. Deprecate previewCitationCluster (using the `@deprecated` JSDoc tag, so TypeScript editors should pick this up and show a warning on use)
2. Add a `previewCluster` that changes the first argument to use an id-less Cluster object, on which you can put a cluster mode, and any future cluster options.
3. Makes the `format` argument optional, because recent wasm-bindgen can do this.
4. Document and test the new stuff, and the deprecated version