### PR TITLE
Adapt to breaking change in rustc 1.66/1.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,9 +798,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
@@ -2097,9 +2097,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tendril"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",

--- a/crates/io/src/output/parse_quotes.rs
+++ b/crates/io/src/output/parse_quotes.rs
@@ -613,7 +613,7 @@ fn new_quote_splitter<'a>(
 }
 
 impl<'a, I: Iterator<Item = SplitPoint>> QuoteSplitter<'a, I> {
-    fn events(self) -> impl Iterator<Item = Event<'a>> {
+    fn events(self) -> impl Iterator<Item = Event<'a>> + 'a {
         self.flat_map(|x: Thingo| x).filter(|ev| match ev {
             Event::Text("") => false,
             _ => true,


### PR DESCRIPTION
Fixes #154. Also updates the `tendril` crate since rustc reported that the previous version would fail to compile in a future version of rustc.